### PR TITLE
Switched from MD5 to MiGS enforced SHA256

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -67,12 +67,12 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
         $hash = null;
         foreach ($data as $k => $v) {
-            if ((strlen($v) > 0) && ((substr($k, 0,4)=="vpc_") || (substr($k,0,5) =="user_"))) {
+            if ((strlen($v) > 0) && ((substr($k, 0, 4)=="vpc_") || (substr($k, 0, 5) =="user_"))) {
                 $hash .= $k . "=" . $v . "&";
             }
         }
         $hash = rtrim($hash, "&");
 
-        return strtoupper(hash_hmac('SHA256', $hash, pack('H*',$this->getSecureHash())));
+        return strtoupper(hash_hmac('SHA256', $hash, pack('H*', $this->getSecureHash())));
     }
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -65,13 +65,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         ksort($data);
 
-        $hash = $this->getSecureHash();
+        $hash = null;
         foreach ($data as $k => $v) {
-            if (substr($k, 0, 4) === 'vpc_' && $k !== 'vpc_SecureHash') {
-                $hash .= $v;
+            if ((strlen($v) > 0) && ((substr($k, 0,4)=="vpc_") || (substr($k,0,5) =="user_"))) {
+                $hash .= $k . "=" . $v . "&";
             }
         }
+        $hash = rtrim($hash, "&");
 
-        return strtoupper(md5($hash));
+        return strtoupper(hash_hmac('SHA256', $hash, pack('H*',$this->getSecureHash())));
     }
 }

--- a/src/Message/ThreePartyPurchaseRequest.php
+++ b/src/Message/ThreePartyPurchaseRequest.php
@@ -15,6 +15,7 @@ class ThreePartyPurchaseRequest extends AbstractRequest
 
         $data = $this->getBaseData();
         $data['vpc_SecureHash']  = $this->calculateHash($data);
+        $data['vpc_SecureHashType']  = 'SHA256';
 
         return $data;
     }

--- a/tests/Message/ThreePartyPurchaseRequestTest.php
+++ b/tests/Message/ThreePartyPurchaseRequestTest.php
@@ -27,7 +27,7 @@ class ThreePartyPurchaseRequestTest extends TestCase
 
         $data = $this->request->getData();
 
-        $this->assertSame('FC86354CC09D414EF308A6FA8CE4F9BB', $data['vpc_SecureHash']);
+        $this->assertSame('F4EAA0FB5C06BDB32ECD6DADCDF7832A119D9E5114CBEFDC228370ECC3AE304F', $data['vpc_SecureHash']);
     }
 
     public function testPurchase()

--- a/tests/Message/TwoPartyPurchaseRequestTest.php
+++ b/tests/Message/TwoPartyPurchaseRequestTest.php
@@ -31,7 +31,7 @@ class TwoPartyPurchaseRequestTest extends TestCase
         $this->request->setSecureHash('123');
         $hash = $this->request->calculateHash($data);
 
-        $this->assertSame('2624B4BABED7CCA98665238D75560600', $hash);
+        $this->assertSame('C3CC125E94B18DBC5C45BBB9606B969854571B4D0A0BFF1940B4A603B3E50417', $hash);
     }
 
     public function testPurchase()


### PR DESCRIPTION
**MiGS starts to enforce SHA-256 in favour of MD5.**

_MiGS supports both MD5 and SHA-256 secure hash methods, however it is strongly
recommended that new merchant integrations use SHA-256. MD5 is supported for
existing merchant integrations._

Not a recent document, but local banks start to enforce.

Reference
http://www.migssupport.com/Resources/Manuals/VirtualPaymentClient/MasterCard%20VPC%20Integration%20Guide%20MR%2029.pdf
