### PR TITLE
Correction in calculateHash()

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -72,7 +72,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
                 continue;
             }
 
-            if ((strlen($v) > 0) && ((substr($k, 0, 4)=="vpc_") || (substr($k, 0, 5) =="user_"))) {
+            if ((strlen($v) > 0)  && ($k != "vpc_SecureHash") && ($k != "vpc_SecureHashType") && ((substr($k, 0, 4)=="vpc_") || (substr($k, 0, 5) =="user_"))) {
                 $hash .= $k . "=" . $v . "&";
             }
         }


### PR DESCRIPTION
With the latest version of the MIGS driver, I could not successfully make a payment, due to an Incorrect Hash error that I'm receiving from Omnipay when returning from a completed order.

Upon checking the docs, I found out that there's something missing in the calculateHash() method. The vpc_SecureHash and vpc_SecureHashType parameters should NOT be included in the hash, as indicated in the revised MIGS documentation and sample PHP codes.

On my end, with the proposed changes, I could now complete my order.
