### PR TITLE
Set correct content type so MIGS picks up the fields

### DIFF
--- a/src/Message/TwoPartyPurchaseRequest.php
+++ b/src/Message/TwoPartyPurchaseRequest.php
@@ -27,7 +27,11 @@ class TwoPartyPurchaseRequest extends AbstractRequest
 
     public function sendData($data)
     {
-        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), [], http_build_query($data));
+        $headers = [
+          'Content-Type'  => 'application/x-www-form-urlencoded',
+        ];
+
+        $httpResponse = $this->httpClient->request('POST', $this->getEndpoint(), $headers, http_build_query($data));
 
         return $this->response = new Response($this, $httpResponse->getBody()->getContents());
     }


### PR DESCRIPTION
All 2 Party Payments I was attempting to process were failing with "Required field vpc_Merchant was not present in the request"

Upon further investigation, no fields that were being sent were being recognized. 

After trying a few content types, this one worked